### PR TITLE
Various improvements

### DIFF
--- a/gitcheck.py
+++ b/gitcheck.py
@@ -219,8 +219,8 @@ def main():
     try:
         opts, args = getopt.getopt(
             sys.argv[1:],
-            "vhri",
-            ["verbose", "help", "remote", "ignore-branch"])
+            "vhri:",
+            ["verbose", "help", "remote", "ignore-branch:"])
     except getopt.GetoptError:
         sys.exit(2)
 


### PR DESCRIPTION
-  Add the possibility to ignore branches based on a regex
  - the regex is passed to -i or --ignore-branch
  - the safest is to pass it single-quoted, in order not to have it on
    interpreted by the shell, and to escape it where appropriate
- Gracefully handle missing branch on remotes
