### PR TITLE
changed the output to show the repository name instead of the absolute path

### DIFF
--- a/gitcheck.py
+++ b/gitcheck.py
@@ -244,7 +244,7 @@ def gitcheck(verbose, checkremote, ignoreBranch, bellOnActionNeeded, shouldClear
     actionNeeded = False
 
     if checkremote:
-        print ("Please waiting, refresh the remote repositories datas")
+        print ("Please wait, refreshing data of remote repositories...")
         for r in repo:
             updateRemote(r)
 


### PR DESCRIPTION
- got rid of a possible trailing slash
- the output shows the repo name instead of an absolute path
- created a new var for the output, since rep is also used for changing into directories
- corrected message to proper English
