### PR TITLE
add followlinks to find repository in symlinks

### DIFF
--- a/gitcheck.py
+++ b/gitcheck.py
@@ -30,7 +30,7 @@ def searchRepositories(dir=None, depth=None):
     startinglevel = curdir.count(os.sep)        
     repo = []
     rsearch = re.compile(r'^/?(.*?)/\.git')
-    for root, dirnames, filenames in os.walk(curdir):
+    for root, dirnames, filenames in os.walk(curdir, followlinks=True):
         level = root.count(os.sep) - startinglevel                
         if depth == None or level <= depth:            
             for dirnames in fnmatch.filter(dirnames, '*.git'):


### PR DESCRIPTION
In my project directory I have some symbolic links to other path.  
I saw that path pointed by symlinks are not listed in gitcheck output so I changed default followlinks options for os.walk().
