### PR TITLE
 fix error when repository path contains one or more spaces

### DIFF
--- a/gitcheck.py
+++ b/gitcheck.py
@@ -241,7 +241,7 @@ def getRemoteRepositories(rep):
 
 # Custom git command
 def gitExec(rep, command):
-    cmd = "cd %(rep)s ; %(command)s" % locals()
+    cmd = "cd \"%(rep)s\" ; %(command)s" % locals()
     cmd = os.popen(cmd)
     return cmd.read()
 


### PR DESCRIPTION
The following error occurs when the repository path (/path/to/repo/with spaces) contains one or more spaces:
sh: line 0: cd: /path/to/repo/with: No such file or directory

This fix solves this error.
