### PR TITLE
Fix failure on bare repositories

### DIFF
--- a/gitcheck.py
+++ b/gitcheck.py
@@ -76,11 +76,9 @@ def searchRepositories():
     for directory, dirnames, filenames in os.walk(curdir):
         level = directory.count(os.sep) - startinglevel
         if gblvars.depth == None or level <= gblvars.depth:
-            for d in dirnames:
-                if d.endswith('.git'):
-                    dirproject = os.path.join(directory, d)[:-5]
-                    showDebug("  Add %s repository" % dirproject)
-                    repo.append(dirproject)
+            if '.git' in dirnames:
+                showDebug("  Add %s repository" % directory)
+                repo.append(directory)
 
     repo.sort()
     showDebug('Done')


### PR DESCRIPTION
Bare repositories are often named "foo.git". If we have a bare repository in "~/src/foo.git", then scanning while "~/src", `d` would be "foo.git", causing `dirproject` to be set to "~/src/fo".

Since `dirnames` contains a list of the directory names we can directly check for ".git" being in the list. This avoids the bug and is a bit faster (no need to check for other elements in `dirnames` once ".git" has been found)