### PR TITLE
Option to check all branches

### DIFF
--- a/coverage.rc
+++ b/coverage.rc
@@ -1,0 +1,24 @@
+# coverage.rc to control coverage.py
+[run]
+omit = /usr/share/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+

--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -473,7 +473,7 @@ def main():
     for opt, arg in opts:
         if opt in ("-v", "--verbose"):
             gblvars.verbose = True
-        elif opt in ("--debug"):
+        elif opt == "--debug":
             gblvars.debugmod = True
         elif opt in ("-r", "--remote"):
             gblvars.checkremote = True

--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -91,7 +91,7 @@ def searchRepositories():
 
 
 # Check state of a git repository
-def checkRepository(rep,branch):
+def checkRepository(rep, branch):
     aitem = []
     mitem = []
     ditem = []
@@ -366,7 +366,7 @@ def gitcheck():
         else:
             branch = getDefaultBranch(r)
         for b in branch:
-            if checkRepository(r,b):
+            if checkRepository(r, b):
                 actionNeeded = True
     html.timestamp = strftime("%Y-%m-%d %H:%M:%S")
     html.msg += "</ul>\n<p>Report created on %s</p>\n" % html.timestamp

--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -35,6 +35,7 @@ class gblvars:
     depth = None
     quiet = False
     ignoreBranch = r'^$'  # empty string
+    ignoreLocal = r'^$'  # empty string
 
 
 # Class for terminal Color
@@ -266,9 +267,10 @@ def getLocalFilesChange(rep):
 
     lines = result.split('\n')
     for l in lines:
-        m = snbchange.match(l)
-        if m:
-            files.append([m.group(1), m.group(2)])
+        if not re.match(gblvars.ignoreLocal, l):
+            m = snbchange.match(l)
+            if m:
+                files.append([m.group(1), m.group(2)])
 
     return files
 
@@ -450,6 +452,7 @@ def usage():
     print("  -q, --quiet                          Display info only when repository needs action")
     print("  -e, --email                          Send an email with result as html, using mail.properties parameters")
     print("  -a, --all-branch                     Show the status of all branches")
+    print("  -l <re>, --localignore=<re>          ignore changes in local files which match the regex <re>")
     print("  --init-email                         Initialize mail.properties file (has to be modified by user using JSON Format)")
 
 
@@ -457,10 +460,10 @@ def main():
     try:
         opts, args = getopt.getopt(
             sys.argv[1:],
-            "vhrubw:i:d:m:q:e:a",
+            "vhrubw:i:d:m:q:e:al:",
             [
                 "verbose", "debug", "help", "remote", "untracked", "bell", "watch=", "ignore-branch=",
-                "dir=", "maxdepth=", "quiet", "email", "init-email", "all-branch"
+                "dir=", "maxdepth=", "quiet", "email", "init-email", "all-branch", "localignore="
             ]
         )
     except getopt.GetoptError as e:
@@ -489,6 +492,8 @@ def main():
                 sys.exit(2)
         elif opt in ("-i", "--ignore-branch"):
             gblvars.ignoreBranch = arg
+        elif opt in ("-l", "--localignore"):
+            gblvars.ignoreLocal = arg
         elif opt in ("-d", "--dir"):
             gblvars.searchDir = arg
         elif opt in ("-m", '--maxdepth'):


### PR DESCRIPTION
I have added an option to check all repository branches.

I kept changes to a minimum where possible, however it was necessary to change the local head comparison code.  Previously it referred to HEAD, now it refers to the top of the branch in question.

This shouldn't make much difference, unless you rely on gitcheck to inform you that you have a detached HEAD.