### PR TITLE
Push / Pull hooks.

### DIFF
--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -68,6 +68,23 @@ def showDebug(mess, level='info'):
     if argopts.get('debugmod', False):
         print(mess)
 
+def makeRepoNameRelative(rep):
+    # Remove trailing slash from repository/directory name
+    if rep[-1:] == '/':
+        rep = rep[:-1]
+
+    # Do some magic to not show the absolute path as repository name
+    # Case 1: script was started in a directory that is a git repo
+    if rep == os.path.abspath(os.getcwd()):
+        (head, tail) = os.path.split(rep)
+        if tail != '':
+            return tail
+    # Case 2: script was started in a directory with possible subdirs that contain git repos
+    elif rep.find(os.path.abspath(os.getcwd())) == 0:
+        return rep[len(os.path.abspath(os.getcwd())) + 1:]
+    # Case 3: script was started with -d and above cases do not apply
+    else:
+        return rep
 
 # Search all local repositories from current directory
 def searchRepositories():
@@ -150,22 +167,7 @@ def checkRepository(rep, branch):
                     count
                 )
     if ischange or not argopts.get('quiet', False):
-        # Remove trailing slash from repository/directory name
-        if rep[-1:] == '/':
-            rep = rep[:-1]
-
-        # Do some magic to not show the absolute path as repository name
-        # Case 1: script was started in a directory that is a git repo
-        if rep == os.path.abspath(os.getcwd()):
-            (head, tail) = os.path.split(rep)
-            if tail != '':
-                repname = tail
-        # Case 2: script was started in a directory with possible subdirs that contain git repos
-        elif rep.find(os.path.abspath(os.getcwd())) == 0:
-            repname = rep[len(os.path.abspath(os.getcwd())) + 1:]
-        # Case 3: script was started with -d and above cases do not apply
-        else:
-            repname = rep
+        repname = makeRepoNameRelative(rep)
 
         if ischange:
             prjname = "%s%s%s" % (colortheme['prjchanged'], repname, colortheme['default'])

--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -472,7 +472,8 @@ def main():
             "vhrubw:i:d:m:q:e:al:",
             [
                 "verbose", "debug", "help", "remote", "untracked", "bell", "watch=", "ignore-branch=",
-                "dir=", "maxdepth=", "quiet", "email", "init-email", "all-branch", "localignore="
+                "dir=", "maxdepth=", "quiet", "email", "init-email", "all-branch", "localignore=",
+                "push-hook=", "pull-hook="
             ]
         )
     except getopt.GetoptError as e:
@@ -527,6 +528,10 @@ def main():
         elif opt in ["-h", "--help"]:
             usage()
             sys.exit(0)
+        elif opt in ["--push-hook"]:
+            argopts["push-hook"] = arg
+        elif opt in ["--pull-hook"]:
+            argopts["pull-hook"] = arg
 #        else:
 #            print "Unhandled option %s" % opt
 #            sys.exit(2)

--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -445,6 +445,16 @@ def readDefaultConfig():
         pass
 
 
+def checkHooks():
+    if "push-hook" in argopts and not os.path.isfile(argopts["push-hook"]):
+        print("push-hook isn't a valid file: %s" % argopts["push-hook"])
+        argopts["push-hook"] = None;
+
+    if "pull-hook" in argopts and not os.path.isfile(argopts["pull-hook"]):
+        print("pull-hook isn't a valid file: %s" % argopts["pull-hook"])
+        argopts["pull-hook"] = None;
+
+
 def usage():
     print("Usage: %s [OPTIONS]" % (sys.argv[0]))
     print("Check multiple git repository in one pass")
@@ -538,6 +548,7 @@ def main():
 
     while True:
         try:
+            checkHooks()
             gitcheck()
 
             if argopts.get('email', False):


### PR DESCRIPTION
Hi @badele!

I'm making this PR not be accepted at all, but to explore the direction that we're going to.
I mean, I tried to implement the hook system very quick and dirty just to give us a way to check if it's what we're looking for at all.

I don't really know if I get you idea correctly (I think I was...), but I found the hook system too broad and general to be really useful (at least for what I was thinking about it). I mean the way that I implemented it, it gives too little context about the repository for me work with.

For example, I just have the repo path (name) and with that I'll need roll all my scripting to iterate in the repo's branches, etc. ```gitcheck``` is already doing that in it's default operation.
I would prefer that ```gitcheck``` call my hook for each branch that needs a push or a pull instead, this way I'll need roll out the scripting to check if it should actually pull, merge, push, etc.

I hope that I made myself clear, and sorry for the delay to implement this, I had some very busy time the last two weeks! 

PS: This is not a PR to be accepted so it's missing a lot of stuff that I'll be included, don't pay attention to that, but to the general idea!

Thanks!