### PR TITLE
Stop traversal at maxdepth

### DIFF
--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -82,12 +82,15 @@ def searchRepositories():
         html.path = curdir
         startinglevel = curdir.count(os.sep)
 
-        for directory, dirnames, filenames in os.walk(curdir):
+        for directory, dirnames, filenames in os.walk(curdir, topdown=True):
             level = directory.count(os.sep) - startinglevel
-            if argopts.get('depth', None) is None or level <= argopts.get('depth', None):
-                if '.git' in dirnames:
-                    showDebug("  Add %s repository" % directory)
-                    repo.add(directory)
+
+            if '.git' in dirnames:
+                showDebug("  Add %s repository" % directory)
+                repo.add(directory)
+
+            if argopts.get('depth', None) is not None and level >= argopts.get('depth', None):
+                dirnames[:] = []
 
     showDebug('Done')
     return sorted(repo)


### PR DESCRIPTION
Hi!

As a somewhat heavy user of `gitcheck` I regularly found that the "first check of the day" took rather long. Turns out that the `maxdepth` parameter was not applied to the actual traversal but only the output.

This PR is a proposal to change that behaviour. It is especially useful when having "cold storage" like after a system restart.

For reference I have measured some timings for my system (the separate number is the number of directories check if it is a git repository).

```
## master (cold storage)
> gitcheck --maxdepth 2 --quiet --dir=/data/projects
40392
2.38s user 2.45s system 19% cpu 24.155 total

## master (hot storage)
> gitcheck --maxdepth 2 --quiet --dir=/data/projects
40392
1.64s user 1.28s system 87% cpu 3.332 total

## traversal (cold storage)
> gitcheck --maxdepth 2 --quiet --dir=/data/projects
199
1.24s user 1.17s system 86% cpu 2.800 total

## traversal (hot storage)
> gitcheck --maxdepth 2 --quiet --dir=/data/projects
199
1.04s user 0.85s system 81% cpu 2.327 total
```

Your mileage obviously varies as both the directory count and timings depend on the type of disk used but it should generally be faster.