### PR TITLE
Make sure that the terminal colors are intact.

### DIFF
--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -25,7 +25,7 @@ from colored import fg, bg, attr
 # Global vars
 argopts = {}
 colortheme = None
-#Load custom parameters from ~/mygitcheck.py
+# Load custom parameters from ~/mygitcheck.py
 configfile = expanduser('~/mygitcheck.py')
 if os.path.exists(configfile):
     sys.path.append(expanduser('~'))
@@ -257,13 +257,13 @@ def checkRepository(rep, branch):
                             if not argopts.get('email', False): print(pcommit)
                         html.msg += '</ul>\n'
 
-    print("\033[0m", end="") ## Reset the terminal colors the original ones.
+    print("\033[0m", end="")    # Reset the terminal colors the original ones.
     return actionNeeded
 
 
 def getLocalFilesChange(rep):
     files = []
-    #curdir = os.path.abspath(os.getcwd())
+    # curdir = os.path.abspath(os.getcwd())
     snbchange = re.compile(r'^(.{2}) (.*)')
     onlyTrackedArg = "" if argopts.get('checkUntracked', False) else "uno"
     result = gitExec(rep, "status -s" + onlyTrackedArg)

--- a/gitcheck/gitcheck.py
+++ b/gitcheck/gitcheck.py
@@ -257,6 +257,7 @@ def checkRepository(rep, branch):
                             if not argopts.get('email', False): print(pcommit)
                         html.msg += '</ul>\n'
 
+    print("\033[0m", end="") ## Reset the terminal colors the original ones.
     return actionNeeded
 
 


### PR DESCRIPTION
We're not resetting the terminal colors after printing the output,
so all the "original" colors of the terminal is messed after running
gitcheck.

Printing the reset escape sequence after printing the output let
the colors as it was before. Even if no colors were output the reset
escape code is harmless.

Messy colors:
![screen shot 2018-07-31 at 23 04 40](https://user-images.githubusercontent.com/40965165/43489828-2d26cc86-9516-11e8-9ab0-94f948c3032b.png)

Tidy colors: 
![screen shot 2018-07-31 at 23 04 55](https://user-images.githubusercontent.com/40965165/43489830-2d5366e2-9516-11e8-9569-8a17b9d7f6fc.png)
